### PR TITLE
Fixes popTo last

### DIFF
--- a/Sources/NavigationRouter/NavigationHandler/NavigationHandler.swift
+++ b/Sources/NavigationRouter/NavigationHandler/NavigationHandler.swift
@@ -93,7 +93,7 @@ public extension NavigationHandler {
     ///   - last: The `View's` `Type` that you want to navigate back to.
     ///
     func popTo<Content: View>(_ last: Content.Type) {
-        guard let index = routerPath.lastIndex(where: { type(of: $0) == last })
+        guard let index = routerPath.lastIndex(where: { type(of: $0.view) == last })
         else { return }
         pop((count - 1) - index)
     }


### PR DESCRIPTION
The popTo(last: Content.Type) function had a bug where it would never navigate back. This should fix that bug.